### PR TITLE
Add params and query to request log

### DIFF
--- a/lib/hapi-logger.js
+++ b/lib/hapi-logger.js
@@ -7,7 +7,9 @@ var bunyan = require('bunyan'),
 			headers: req.headers,
 			method: req.method,
 			info: req.info,
-			path: req.path
+			path: req.path,
+			params: req.params,
+			query: req.query
 		};
 		return obj;
 	},


### PR DESCRIPTION
I think request's params and query are useful for logging.
